### PR TITLE
Students page: correct annotations

### DIFF
--- a/students.html
+++ b/students.html
@@ -56,7 +56,7 @@ permalink: /students.html
     </div>
     <div class="students-group">
       <span class="students-group__label students-group__label--phd-cz">博士生（创智）</span>
-      <p class="students-group__names">王思尹（卓博）、施君豪、李睿潇（卓博，共同导师：黄萱菁）、葛煦旸（硕博）、纪力（硕博）、舒文韬（硕博）、徐哲（硕博）、张羽乾（硕博）、赵奕伟（硕博）</p>
+      <p class="students-group__names">王思尹（卓博）、施君豪（直博）、李睿潇（卓博，共同导师：黄萱菁）、葛煦旸（硕博）、纪力（硕博）、舒文韬（硕博）、徐哲（硕博）、张羽乾（硕博）、赵奕伟（硕博）</p>
     </div>
     <div class="students-group">
       <span class="students-group__label students-group__label--ms">硕士生</span>
@@ -84,7 +84,7 @@ permalink: /students.html
   <div class="entry__body">
     <div class="students-group">
       <span class="students-group__label students-group__label--phd">博士生</span>
-      <p class="students-group__names">柳潇然（硕博）、王鹏宇（硕博）、詹俊（硕博）、王博（卓博）、王星皓（直博）、邵云帆（2022–2025，日行迹）、代俊奇（共同导师：黄萱菁）、徐凝雨</p>
+      <p class="students-group__names">柳潇然（硕博）、王鹏宇（硕博）、詹俊（硕博）、王博（卓博）、王星皓（直博）、邵云帆（2022–2025，日行迹）、代俊奇（共同导师：黄萱菁）、徐凝雨（直博，共同导师：黄萱菁）</p>
     </div>
     <div class="students-group">
       <span class="students-group__label students-group__label--ms">硕士生</span>
@@ -98,11 +98,11 @@ permalink: /students.html
   <div class="entry__body">
     <div class="students-group">
       <span class="students-group__label students-group__label--phd">博士生</span>
-      <p class="students-group__names">程沁源（2020–2025，硕博，模思智能）、汪燠欣（2021–2026，卓博，共同导师：黄萱菁，SII）、刘佩举（硕博）、吕凯（硕博）、印张悦（硕博）</p>
+      <p class="students-group__names">程沁源（2021–2026，硕博，模思智能）、汪燠欣（2021–2026，卓博，共同导师：黄萱菁，上海创智学院）、刘佩举（硕博）、吕凯（2021–2026，硕博）、印张悦（2021–2026，硕博）</p>
     </div>
     <div class="students-group">
       <span class="students-group__label students-group__label--ms">硕士生</span>
-      <p class="students-group__names">常成（模思智能）、胡先念（阿里）、洪嘉伟（上海人工智能实验室）、李鹏（SII）、刘腾霄（UCSB, PHD）、权国风（阿里）、孙瑜（上海人工智能实验室）、吴玲玲（Optiver）、吴嘉文（世纪前沿）、杨小珪（上海人工智能实验室）、杨雨晴（USC, PHD）、张啸天（创业）、郑彦俊（蚂蚁）</p>
+      <p class="students-group__names">常成（模思智能）、胡先念（阿里）、洪嘉伟（上海人工智能实验室）、李鹏（上海创智学院）、刘腾霄（UCSB, PHD）、权国风（阿里）、孙瑜（上海人工智能实验室）、吴玲玲（Optiver）、吴嘉文（世纪前沿）、杨小珪（上海人工智能实验室）、杨雨晴（USC, PHD）、张啸天（创业）、郑彦俊（蚂蚁）</p>
     </div>
   </div>
 </li>
@@ -112,7 +112,7 @@ permalink: /students.html
   <div class="entry__body">
     <div class="students-group">
       <span class="students-group__label students-group__label--phd">博士生</span>
-      <p class="students-group__names">李孝男（2020–2025，直博，USA Apple）、周云华（2020–2023，上海人工智能实验室）、李世民（2020–2025，硕博，模思智能）、刘向阳（2020–2025，硕博，日行迹）、罗琪（2020–2025，硕博，模思智能）</p>
+      <p class="students-group__names">李孝男（2020–2025，直博，USA Apple）、周云华（2020–2023，上海人工智能实验室）、李世民（2020–2025，硕博，模思智能）、刘向阳（2020–2025，硕博，日行迹）、罗琪（2020–2026，硕博，模思智能）</p>
     </div>
     <div class="students-group">
       <span class="students-group__label students-group__label--ms">硕士生</span>
@@ -126,7 +126,7 @@ permalink: /students.html
   <div class="entry__body">
     <div class="students-group">
       <span class="students-group__label students-group__label--phd">博士生</span>
-      <p class="students-group__names">颜航（2019–2023，上海人工智能实验室）、李林阳（2019–2024，上海人工智能实验室）、孙天祥（2019–2024，共同导师：黄萱菁，日行迹）、郑逸宁（2019–2025，硕博，复旦大学）</p>
+      <p class="students-group__names">颜航（2019–2023，上海人工智能实验室）、李林阳（2019–2024，硕博，上海人工智能实验室）、孙天祥（2019–2024，直博，共同导师：黄萱菁，日行迹）、郑逸宁（2019–2025，硕博，复旦大学）</p>
     </div>
     <div class="students-group">
       <span class="students-group__label students-group__label--ms">硕士生</span>
@@ -311,12 +311,15 @@ permalink: /students.html
     '创智':     'tag--cz',
     '浦江联培': 'tag--pujiang'
   };
-  var TAG_RE = /(硕博|直博|卓博|创智|浦江联培)/g;
+  var TAG_RE = /(硕博|直博|卓博|浦江联培)/g;
   /* Year-range pattern at start (e.g. "2019–2025" or "2014-2019") signals
      a graduated student; the last item then carries their destination. */
   var YEAR_RANGE_RE = /^\s*\d{4}\s*[-–—]\s*\d{4}\s*$/;
 
   function tagify(s) {
+    if (s.trim() === '创智') {
+      return s.replace('创智', '<span class="tag ' + TAG_CLASS['创智'] + '">创智</span>');
+    }
     return s.replace(TAG_RE, function (kw) {
       return '<span class="tag ' + TAG_CLASS[kw] + '">' + kw + '</span>';
     });


### PR DESCRIPTION
- 2019: mark 李林阳 as 硕博 and 孙天祥 as 直博 while preserving mentor and destination details.
- 2020: extend 罗琪 to 2020–2026.
- 2021: update 程沁源 / 吕凯 / 印张悦 to 2021–2026 and replace SII destinations with 上海创智学院 for 汪燠欣 and 李鹏.
- 2022: add 徐凝雨 as 直博 with 黄萱菁 as co-advisor.
- 2024: mark 施君豪 as 直博.
- Tag styling now only highlights standalone 创智 annotations, so 上海创智学院 stays plain text.